### PR TITLE
zcbor_encode.c: Don't call memmove with NULL strings

### DIFF
--- a/src/zcbor_encode.c
+++ b/src/zcbor_encode.c
@@ -318,10 +318,13 @@ static bool str_encode(zcbor_state_t *state,
 	if (input->len > (size_t)(state->payload_end - state->payload)) {
 		ZCBOR_ERR(ZCBOR_ERR_NO_PAYLOAD);
 	}
+	if (!input->value && (input->len > 0)) {
+		ZCBOR_ERR(ZCBOR_ERR_BAD_ARG);
+	}
 	if (!str_start_encode(state, input, major_type)) {
 		ZCBOR_FAIL();
 	}
-	if (state->payload_mut != input->value) {
+	if ((state->payload_mut != input->value) && (input->len > 0)) {
 		/* Use memmove since string might be encoded into the same space
 		 * because of zcbor_bstr_start_encode/zcbor_bstr_end_encode. */
 		memmove(state->payload_mut, input->value, input->len);

--- a/tests/unit/test1_unit_tests/src/main.c
+++ b/tests/unit/test1_unit_tests/src/main.c
@@ -618,6 +618,26 @@ ZTEST(zcbor_unit_tests, test_null_state)
 }
 
 
+ZTEST(zcbor_unit_tests, test_null_params)
+{
+	uint8_t payload[10];
+	ZCBOR_STATE_E(state_e, 0, payload, sizeof(payload), 0);
+	struct zcbor_string dummy_string = {0};
+	uint8_t hello[] = "Hello";
+
+	zassert_true(zcbor_bstr_encode(state_e, &dummy_string), NULL);
+	dummy_string.len = 5;
+	zassert_false(zcbor_bstr_encode(state_e, &dummy_string), NULL);
+	zassert_equal(ZCBOR_ERR_BAD_ARG, zcbor_peek_error(state_e), NULL);
+	dummy_string.value = hello;
+	zassert_true(zcbor_bstr_encode(state_e, &dummy_string), NULL);
+
+	uint8_t exp_payload[] = {0x40, 0x45, 0x48, 0x65, 0x6c, 0x6c, 0x6f};
+	zassert_equal(sizeof(exp_payload), state_e->payload - payload, NULL);
+	zassert_mem_equal(exp_payload, payload, sizeof(exp_payload), NULL);
+}
+
+
 /** The string "HelloWorld" is split into 2 fragments, and a number of different
  * functions are called to test that they respond correctly to the situation.
 **/


### PR DESCRIPTION
It's undefined behavior, even if the length is 0.

Fixes #608 